### PR TITLE
Fixing Serialization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,8 @@ php:
   - 5.5
 
 before_script:
+  - composer selfupdate
   - composer install --prefer-source --dev
   - phpenv rehash
-  
-script: phpunit --coverage-text
+
+script: vendor/bin/phpunit --coverage-text

--- a/composer.json
+++ b/composer.json
@@ -11,13 +11,14 @@
     ],
 
     "require": {
-        "guzzle/guzzle": "~3.1"
+        "guzzle/guzzle": "~3.7"
     },
 
     "require-dev": {
         "symfony/css-selector": "~2.2",
         "symfony/dom-crawler": "~2.2",
-        "symfony/console": "~2.2"
+        "symfony/console": "~2.2",
+        "phpunit/phpunit": "~3.7"
     },
 
     "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -1,23 +1,27 @@
 {
-    "hash": "a7f5204e322fb25a2925c20155d9dded",
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file"
+    ],
+    "hash": "29c2ed94c44175ce9a886f1c381a2b8f",
     "packages": [
         {
             "name": "guzzle/guzzle",
-            "version": "v3.3.1",
+            "version": "v3.7.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "v3.3.1"
+                "reference": "b170b028c6bb5799640e46c8803015b0f9a45ed9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/v3.3.1",
-                "reference": "v3.3.1",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/b170b028c6bb5799640e46c8803015b0f9a45ed9",
+                "reference": "b170b028c6bb5799640e46c8803015b0f9a45ed9",
                 "shasum": ""
             },
             "require": {
                 "ext-curl": "*",
-                "php": ">=5.3.2",
+                "php": ">=5.3.3",
                 "symfony/event-dispatcher": ">=2.1"
             },
             "replace": {
@@ -48,16 +52,15 @@
                 "doctrine/cache": "*",
                 "monolog/monolog": "1.*",
                 "phpunit/phpunit": "3.7.*",
+                "psr/log": "1.0.*",
                 "symfony/class-loader": "*",
-                "zend/zend-cache1": "1.12",
-                "zend/zend-log1": "1.12",
                 "zendframework/zend-cache": "2.0.*",
                 "zendframework/zend-log": "2.0.*"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.3-dev"
+                    "dev-master": "3.7-dev"
                 }
             },
             "autoload": {
@@ -92,37 +95,37 @@
                 "rest",
                 "web service"
             ],
-            "time": "2013-03-10 23:05:38"
+            "time": "2013-10-02 20:47:00"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v2.2.0",
+            "version": "v2.3.6",
             "target-dir": "Symfony/Component/EventDispatcher",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/EventDispatcher.git",
-                "reference": "v2.2.0-RC3"
+                "reference": "7fc72a7a346a1887d3968cc1ce5642a15cd182e9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/EventDispatcher/zipball/v2.2.0-RC3",
-                "reference": "v2.2.0-RC3",
+                "url": "https://api.github.com/repos/symfony/EventDispatcher/zipball/7fc72a7a346a1887d3968cc1ce5642a15cd182e9",
+                "reference": "7fc72a7a346a1887d3968cc1ce5642a15cd182e9",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3"
             },
             "require-dev": {
-                "symfony/dependency-injection": ">=2.0,<3.0"
+                "symfony/dependency-injection": "~2.0"
             },
             "suggest": {
-                "symfony/dependency-injection": "2.2.*",
-                "symfony/http-kernel": "2.2.*"
+                "symfony/dependency-injection": "",
+                "symfony/http-kernel": ""
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.2-dev"
+                    "dev-master": "2.3-dev"
                 }
             },
             "autoload": {
@@ -146,32 +149,405 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "http://symfony.com",
-            "time": "2013-02-11 11:26:43"
+            "time": "2013-09-19 09:45:20"
         }
     ],
     "packages-dev": [
         {
-            "name": "symfony/console",
-            "version": "v2.2.0",
-            "target-dir": "Symfony/Component/Console",
+            "name": "phpunit/php-code-coverage",
+            "version": "1.2.13",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/Console.git",
-                "reference": "v2.2.0"
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "466e7cd2554b4e264c9e3f31216d25ac0e5f3d94"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Console/zipball/v2.2.0",
-                "reference": "v2.2.0",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/466e7cd2554b4e264c9e3f31216d25ac0e5f3d94",
+                "reference": "466e7cd2554b4e264c9e3f31216d25ac0e5f3d94",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "phpunit/php-file-iterator": ">=1.3.0@stable",
+                "phpunit/php-text-template": ">=1.1.1@stable",
+                "phpunit/php-token-stream": ">=1.1.3@stable"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "3.7.*@dev"
+            },
+            "suggest": {
+                "ext-dom": "*",
+                "ext-xdebug": ">=2.0.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.2.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "PHP/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "include-path": [
+                ""
+            ],
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
+            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
+            "keywords": [
+                "coverage",
+                "testing",
+                "xunit"
+            ],
+            "time": "2013-09-10 08:14:32"
+        },
+        {
+            "name": "phpunit/php-file-iterator",
+            "version": "1.3.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
+                "reference": "acd690379117b042d1c8af1fafd61bde001bf6bb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/acd690379117b042d1c8af1fafd61bde001bf6bb",
+                "reference": "acd690379117b042d1c8af1fafd61bde001bf6bb",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3"
             },
             "type": "library",
+            "autoload": {
+                "classmap": [
+                    "File/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "include-path": [
+                ""
+            ],
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
+            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
+            "keywords": [
+                "filesystem",
+                "iterator"
+            ],
+            "time": "2013-10-10 15:34:57"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "1.1.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "5180896f51c5b3648ac946b05f9ec02be78a0b23"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/5180896f51c5b3648ac946b05f9ec02be78a0b23",
+                "reference": "5180896f51c5b3648ac946b05f9ec02be78a0b23",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "Text/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "include-path": [
+                ""
+            ],
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Simple template engine.",
+            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
+            "keywords": [
+                "template"
+            ],
+            "time": "2012-10-31 18:15:28"
+        },
+        {
+            "name": "phpunit/php-timer",
+            "version": "1.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-timer.git",
+                "reference": "19689d4354b295ee3d8c54b4f42c3efb69cbc17c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/19689d4354b295ee3d8c54b4f42c3efb69cbc17c",
+                "reference": "19689d4354b295ee3d8c54b4f42c3efb69cbc17c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "PHP/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "include-path": [
+                ""
+            ],
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Utility class for timing",
+            "homepage": "https://github.com/sebastianbergmann/php-timer/",
+            "keywords": [
+                "timer"
+            ],
+            "time": "2013-08-02 07:42:54"
+        },
+        {
+            "name": "phpunit/php-token-stream",
+            "version": "1.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-token-stream.git",
+                "reference": "5220af2a7929aa35cf663d97c89ad3d50cf5fa3e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/5220af2a7929aa35cf663d97c89ad3d50cf5fa3e",
+                "reference": "5220af2a7929aa35cf663d97c89ad3d50cf5fa3e",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": ">=5.3.3"
+            },
+            "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.2-dev"
+                    "dev-master": "1.2-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "PHP/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "include-path": [
+                ""
+            ],
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Wrapper around PHP's tokenizer extension.",
+            "homepage": "https://github.com/sebastianbergmann/php-token-stream/",
+            "keywords": [
+                "tokenizer"
+            ],
+            "time": "2013-09-13 04:58:23"
+        },
+        {
+            "name": "phpunit/phpunit",
+            "version": "3.7.28",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit.git",
+                "reference": "3b97c8492bcafbabe6b6fbd2ab35f2f04d932a8d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/3b97c8492bcafbabe6b6fbd2ab35f2f04d932a8d",
+                "reference": "3b97c8492bcafbabe6b6fbd2ab35f2f04d932a8d",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-pcre": "*",
+                "ext-reflection": "*",
+                "ext-spl": "*",
+                "php": ">=5.3.3",
+                "phpunit/php-code-coverage": "~1.2.1",
+                "phpunit/php-file-iterator": ">=1.3.1",
+                "phpunit/php-text-template": ">=1.1.1",
+                "phpunit/php-timer": ">=1.0.4",
+                "phpunit/phpunit-mock-objects": "~1.2.0",
+                "symfony/yaml": "~2.0"
+            },
+            "require-dev": {
+                "pear-pear/pear": "1.9.4"
+            },
+            "suggest": {
+                "ext-json": "*",
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "phpunit/php-invoker": ">=1.1.0,<1.2.0"
+            },
+            "bin": [
+                "composer/bin/phpunit"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.7.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "PHPUnit/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "include-path": [
+                "",
+                "../../symfony/yaml/"
+            ],
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "The PHP Unit Testing framework.",
+            "homepage": "http://www.phpunit.de/",
+            "keywords": [
+                "phpunit",
+                "testing",
+                "xunit"
+            ],
+            "time": "2013-10-17 07:27:40"
+        },
+        {
+            "name": "phpunit/phpunit-mock-objects",
+            "version": "1.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
+                "reference": "5794e3c5c5ba0fb037b11d8151add2a07fa82875"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/5794e3c5c5ba0fb037b11d8151add2a07fa82875",
+                "reference": "5794e3c5c5ba0fb037b11d8151add2a07fa82875",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "phpunit/php-text-template": ">=1.1.1@stable"
+            },
+            "suggest": {
+                "ext-soap": "*"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "PHPUnit/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "include-path": [
+                ""
+            ],
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Mock Object library for PHPUnit",
+            "homepage": "https://github.com/sebastianbergmann/phpunit-mock-objects/",
+            "keywords": [
+                "mock",
+                "xunit"
+            ],
+            "time": "2013-01-13 10:24:48"
+        },
+        {
+            "name": "symfony/console",
+            "version": "v2.3.6",
+            "target-dir": "Symfony/Component/Console",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/Console.git",
+                "reference": "f880062d56edefb25b36f2defa65aafe65959dc7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/Console/zipball/f880062d56edefb25b36f2defa65aafe65959dc7",
+                "reference": "f880062d56edefb25b36f2defa65aafe65959dc7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "symfony/event-dispatcher": "~2.1"
+            },
+            "suggest": {
+                "symfony/event-dispatcher": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.3-dev"
                 }
             },
             "autoload": {
@@ -195,21 +571,21 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "http://symfony.com",
-            "time": "2013-03-01 06:43:14"
+            "time": "2013-09-25 06:04:15"
         },
         {
             "name": "symfony/css-selector",
-            "version": "v2.2.0",
+            "version": "v2.3.6",
             "target-dir": "Symfony/Component/CssSelector",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/CssSelector.git",
-                "reference": "v2.2.0-RC3"
+                "reference": "4e01c74f19ea049773fa3ee9fb2bb5bf5e14f7eb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/CssSelector/zipball/v2.2.0-RC3",
-                "reference": "v2.2.0-RC3",
+                "url": "https://api.github.com/repos/symfony/CssSelector/zipball/4e01c74f19ea049773fa3ee9fb2bb5bf5e14f7eb",
+                "reference": "4e01c74f19ea049773fa3ee9fb2bb5bf5e14f7eb",
                 "shasum": ""
             },
             "require": {
@@ -218,7 +594,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.2-dev"
+                    "dev-master": "2.3-dev"
                 }
             },
             "autoload": {
@@ -238,40 +614,44 @@
                 {
                     "name": "Symfony Community",
                     "homepage": "http://symfony.com/contributors"
+                },
+                {
+                    "name": "Jean-François Simon",
+                    "email": "jeanfrancois.simon@sensiolabs.com"
                 }
             ],
             "description": "Symfony CssSelector Component",
             "homepage": "http://symfony.com",
-            "time": "2013-01-17 15:25:59"
+            "time": "2013-09-19 09:45:20"
         },
         {
             "name": "symfony/dom-crawler",
-            "version": "v2.2.0",
+            "version": "v2.3.6",
             "target-dir": "Symfony/Component/DomCrawler",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/DomCrawler.git",
-                "reference": "v2.2.0"
+                "reference": "f3c321861994f5a1882b4045ea1f8759be47601a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/DomCrawler/zipball/v2.2.0",
-                "reference": "v2.2.0",
+                "url": "https://api.github.com/repos/symfony/DomCrawler/zipball/f3c321861994f5a1882b4045ea1f8759be47601a",
+                "reference": "f3c321861994f5a1882b4045ea1f8759be47601a",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3"
             },
             "require-dev": {
-                "symfony/css-selector": ">=2.0,<3.0"
+                "symfony/css-selector": "~2.0"
             },
             "suggest": {
-                "symfony/css-selector": "2.2.*"
+                "symfony/css-selector": ""
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.2-dev"
+                    "dev-master": "2.3-dev"
                 }
             },
             "autoload": {
@@ -295,7 +675,54 @@
             ],
             "description": "Symfony DomCrawler Component",
             "homepage": "http://symfony.com",
-            "time": "2013-03-01 06:43:14"
+            "time": "2013-09-25 09:22:53"
+        },
+        {
+            "name": "symfony/yaml",
+            "version": "v2.3.6",
+            "target-dir": "Symfony/Component/Yaml",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/Yaml.git",
+                "reference": "6bb881b948368482e1abf1a75c08bcf88a1c5fc3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/Yaml/zipball/6bb881b948368482e1abf1a75c08bcf88a1c5fc3",
+                "reference": "6bb881b948368482e1abf1a75c08bcf88a1c5fc3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Symfony\\Component\\Yaml\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "http://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Yaml Component",
+            "homepage": "http://symfony.com",
+            "time": "2013-09-22 18:04:39"
         }
     ],
     "aliases": [

--- a/src/DMS/Service/Meetup/Command/MeetupResponseParser.php
+++ b/src/DMS/Service/Meetup/Command/MeetupResponseParser.php
@@ -37,31 +37,27 @@ class MeetupResponseParser extends DefaultResponseParser
         $responseArray = $this->parseResponseIntoArray($response);
 
         // If there is no Body, just return the Response
-        if ( ! $response->getBody()) {
+        if (! $response->getBody()) {
             return $response;
         }
 
         // Handle multi-result responses
         if (array_key_exists('results', $responseArray)) {
-            return $this->createMultiResultResponse($response, $responseArray);
+            return $this->createMultiResultResponse($response);
         }
 
-        return $this->createSingleResultResponse($response, $responseArray);
+        return $this->createSingleResultResponse($response);
     }
 
     /**
      * Create a Multi-Response Object
      *
      * @param Response $response
-     * @param array $responseArray
      * @return \DMS\Service\Meetup\Response\MultiResultResponse
      */
-    protected function createMultiResultResponse($response, $responseArray)
+    protected function createMultiResultResponse($response)
     {
         $response = new MultiResultResponse($response->getStatusCode(), $response->getHeaders(), $response->getBody());
-
-        $response->setMetadata($responseArray['meta']);
-        $response->setData($responseArray['results']);
 
         return $response;
     }
@@ -70,14 +66,11 @@ class MeetupResponseParser extends DefaultResponseParser
      * Create a Single-Response Object
      *
      * @param Response $response
-     * @param array $responseArray
      * @return \DMS\Service\Meetup\Response\SingleResultResponse
      */
-    protected function createSingleResultResponse($response, $responseArray)
+    protected function createSingleResultResponse($response)
     {
         $response = new SingleResultResponse($response->getStatusCode(), $response->getHeaders(), $response->getBody());
-
-        $response->setData($responseArray);
 
         return $response;
     }

--- a/src/DMS/Service/Meetup/Response/MultiResultResponse.php
+++ b/src/DMS/Service/Meetup/Response/MultiResultResponse.php
@@ -3,54 +3,18 @@
 namespace DMS\Service\Meetup\Response;
 
 use Closure;
-use Guzzle\Http\Message\Response as BaseResponse;
 
-class MultiResultResponse extends BaseResponse implements \Countable, \Iterator
+class MultiResultResponse extends SelfParsingResponse implements \Countable, \Iterator
 {
-    /**
-     * Data returned from Request
-     *
-     * @var array
-     */
-    protected $data;
 
     /**
-     * Metadata returned by API
-     *
-     * @var array
+     * Makes Meetup API Data available on the Data attribute
      */
-    protected $metadata;
-
-    /**
-     * @param array $data
-     */
-    public function setData($data)
+    public function parseMeetupApiData()
     {
-        $this->data = $data;
-    }
-
-    /**
-     * @return array
-     */
-    public function getData()
-    {
-        return $this->data;
-    }
-
-    /**
-     * @param array $metadata
-     */
-    public function setMetadata($metadata)
-    {
-        $this->metadata = $metadata;
-    }
-
-    /**
-     * @return array
-     */
-    public function getMetadata()
-    {
-        return $this->metadata;
+        $responseBody = $this->parseBodyContent();
+        $this->setData($responseBody['results']);
+        $this->setMetadata($responseBody['meta']);
     }
 
     /**

--- a/src/DMS/Service/Meetup/Response/SelfParsingResponse.php
+++ b/src/DMS/Service/Meetup/Response/SelfParsingResponse.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace DMS\Service\Meetup\Response;
+
+use Guzzle\Http\Message\Response;
+
+class SelfParsingResponse extends Response
+{
+
+    /**
+     * Data returned from Request
+     *
+     * @var array
+     */
+    protected $data;
+
+    /**
+     * Metadata returned by API
+     *
+     * @var array
+     */
+    protected $metadata;
+
+    public function __construct($statusCode, $headers = null, $body = null)
+    {
+        parent::__construct($statusCode, $headers, $body);
+        $this->parseMeetupApiData();
+    }
+
+    /**
+     * @param array $data
+     */
+    public function setData($data)
+    {
+        $this->data = $data;
+    }
+
+    /**
+     * @return array
+     */
+    public function getData()
+    {
+        return $this->data;
+    }
+
+    /**
+     * @param array $metadata
+     */
+    public function setMetadata($metadata)
+    {
+        $this->metadata = $metadata;
+    }
+
+    /**
+     * @return array
+     */
+    public function getMetadata()
+    {
+        return $this->metadata;
+    }
+
+    /**
+     * Parses the Meetup Response based on content type.
+     *
+     * @return array
+     */
+    public function parseBodyContent()
+    {
+        if (strpos($this->getContentType(), 'json') === false) {
+            parse_str($this->getBody(true), $array);
+
+            return $array;
+        }
+
+        return $this->json();
+    }
+
+    /**
+     * Makes Meetup API Data available on the Data attribute
+     */
+    public function parseMeetupApiData()
+    {
+        $responseBody = $this->parseBodyContent();
+        $this->setData($responseBody);
+    }
+
+    /**
+     * Returns true array representation of Response
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+        return $this->data;
+    }
+}

--- a/src/DMS/Service/Meetup/Response/SingleResultResponse.php
+++ b/src/DMS/Service/Meetup/Response/SingleResultResponse.php
@@ -11,54 +11,8 @@ use Guzzle\Http\Message\Response as BaseResponse;
  *
  * @package DMS\Service\Meetup\Response
  */
-class SingleResultResponse extends BaseResponse implements \ArrayAccess
+class SingleResultResponse extends SelfParsingResponse implements \ArrayAccess
 {
-
-    /**
-     * Data returned from Request
-     *
-     * @var array
-     */
-    protected $data;
-
-    /**
-     * Metadata returned by API
-     *
-     * @var array
-     */
-    protected $metadata;
-
-    /**
-     * @param array $data
-     */
-    public function setData($data)
-    {
-        $this->data = $data;
-    }
-
-    /**
-     * @return array
-     */
-    public function getData()
-    {
-        return $this->data;
-    }
-
-    /**
-     * @param array $metadata
-     */
-    public function setMetadata($metadata)
-    {
-        $this->metadata = $metadata;
-    }
-
-    /**
-     * @return array
-     */
-    public function getMetadata()
-    {
-        return $this->metadata;
-    }
 
     /**
      * (PHP 5 &gt;= 5.0.0)<br/>
@@ -124,15 +78,5 @@ class SingleResultResponse extends BaseResponse implements \ArrayAccess
     public function offsetUnset($offset)
     {
         unset($this->data[$offset]);
-    }
-
-    /**
-     * Returns true array representation of Response
-     *
-     * @return array
-     */
-    public function toArray()
-    {
-        return $this->data;
     }
 }

--- a/tests/DMS/Service/Meetup/MeetupKeyAuthClientTest.php
+++ b/tests/DMS/Service/Meetup/MeetupKeyAuthClientTest.php
@@ -15,8 +15,8 @@ class MeetupKeyAuthClientTest extends GuzzleTestCase
     }
 
     /**
-     * @expectedException Guzzle\Common\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Config must contain a 'key' key
+     * @expectedException \Guzzle\Common\Exception\InvalidArgumentException
+     * @expectedExceptionMessage Config is missing the following keys: key
      */
     public function testFactoryValidation()
     {

--- a/tests/DMS/Service/Meetup/Response/MultiResultResponseTest.php
+++ b/tests/DMS/Service/Meetup/Response/MultiResultResponseTest.php
@@ -1,0 +1,40 @@
+<?php
+
+
+namespace DMS\Service\Meetup\Response;
+
+use Guzzle\Common\Collection;
+
+class MultiResultResponseTest extends \PHPUnit_Framework_TestCase
+{
+    public function testSerialization()
+    {
+        $code = 200;
+
+        $headers = new Collection(array(
+            'Content-Type' => 'application/json'
+        ));
+
+        $content = json_encode(array(
+            'meta' => array('self' => 'me'),
+            'results' => array(
+                array('id' => 1),
+                array('id' => 2),
+            ),
+        ));
+
+        $response = new MultiResultResponse($code, $headers, $content);
+
+        $serialized = serialize($response);
+
+        $this->assertNotContains('data', $serialized);
+        $this->assertNotContains('metadata', $serialized);
+
+        $unserialized = unserialize($serialized);
+
+        $this->assertEquals($response->getData(), $unserialized->getData());
+        $this->assertEquals($response->getMetadata(), $unserialized->getMetadata());
+
+        $this->assertInternalType('array', $unserialized->getData());
+    }
+}

--- a/tests/DMS/Service/Meetup/Response/SingleResultResponseTest.php
+++ b/tests/DMS/Service/Meetup/Response/SingleResultResponseTest.php
@@ -1,0 +1,37 @@
+<?php
+
+
+namespace DMS\Service\Meetup\Response;
+
+use Guzzle\Common\Collection;
+
+class SingleResultResponseTest extends \PHPUnit_Framework_TestCase
+{
+    public function testSerialization()
+    {
+        $code = 200;
+
+        $headers = new Collection(array(
+            'Content-Type' => 'application/json'
+        ));
+
+        $content = json_encode(array(
+            array('id' => 1),
+            array('id' => 2),
+        ));
+
+        $response = new SingleResultResponse($code, $headers, $content);
+
+        $serialized = serialize($response);
+
+        $this->assertNotContains('data', $serialized);
+        $this->assertNotContains('metadata', $serialized);
+
+        $unserialized = unserialize($serialized);
+
+        $this->assertEquals($response->getData(), $unserialized->getData());
+        $this->assertEquals($response->getMetadata(), $unserialized->getMetadata());
+
+        $this->assertInternalType('array', $unserialized->getData());
+    }
+}


### PR DESCRIPTION
In Guzzle 3.7 the Response started implementing the Serializable interface.
This affected the serialization of our responses, since data and metadata were now dropped.
Updated this by moving response content parsing into the response objects, allowing
unserialize method to properly rebuild the response.

Updating Dev dependencies
Updating Travis config.

Closes #6 
