### PR TITLE
Added Accept header to Guzzle request

### DIFF
--- a/src/DMS/Service/Meetup/AbstractMeetupClient.php
+++ b/src/DMS/Service/Meetup/AbstractMeetupClient.php
@@ -156,7 +156,8 @@ abstract class AbstractMeetupClient extends Client
         $config = Collection::fromConfig($config, $default, $required);
 
         $standardHeaders = array(
-            'Accept-Charset' => 'utf-8'
+            'Accept-Charset' => 'utf-8',
+            'Accept' => 'application/json',
         );
 
         $requestOptions = array(


### PR DESCRIPTION
Without the Accept header set, the Meetup API with throw a `406 Not Acceptable` error.