### PR TITLE
Documentation Tweak

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ foreach ($response as $responseItem) {
 }
 ```
 
+For a list of all the available commands, see the [Meetup API documentation on ReadTheDocs](http://meetup-api.readthedocs.org/en/latest/meetup_api.html#api-client-method-index)
+
 ## Response
 
 This wrapper implements two types of custom responses to facilitate the usage of the results directly.


### PR DESCRIPTION
I've added a link to the Meetup Commands the library is able to call on the API. When implementing this library I had a job finding a detailed list of what is available, so figured others might find it useful to have a link to this detailed in the readme