### PR TITLE
Refactor client API to simplify things a bit

### DIFF
--- a/src/DMS/Service/Meetup/Command/MeetupResponseParser.php
+++ b/src/DMS/Service/Meetup/Command/MeetupResponseParser.php
@@ -36,16 +36,12 @@ class MeetupResponseParser extends DefaultResponseParser
     {
         $response = $command->getRequest()->getResponse();
 
-        if ($response === null) {
-            return;
+        // If there is no response or Body, just return it
+        if ($response === null || !$response->getBody()) {
+            return $response;
         }
 
         $responseArray = $this->parseResponseIntoArray($response);
-
-        // If there is no Body, just return the Response
-        if (!$response->getBody()) {
-            return $response;
-        }
 
         // Handle multi-result responses
         if (array_key_exists('results', $responseArray)) {
@@ -78,9 +74,7 @@ class MeetupResponseParser extends DefaultResponseParser
      */
     protected function createSingleResultResponse($response)
     {
-        $response = new SingleResultResponse($response->getStatusCode(), $response->getHeaders(), $response->getBody());
-
-        return $response;
+        return new SingleResultResponse($response->getStatusCode(), $response->getHeaders(), $response->getBody());
     }
 
     /**
@@ -92,7 +86,7 @@ class MeetupResponseParser extends DefaultResponseParser
      */
     protected function parseResponseIntoArray($response)
     {
-        if (strpos($response->getContentType(), 'json') === false) {
+        if (!$response->isContentType('json')) {
             parse_str($response->getBody(true), $array);
 
             return $array;

--- a/src/DMS/Service/Meetup/Response/MultiResultResponse.php
+++ b/src/DMS/Service/Meetup/Response/MultiResultResponse.php
@@ -2,32 +2,28 @@
 
 namespace DMS\Service\Meetup\Response;
 
+use ArrayIterator;
 use Closure;
 use Guzzle\Http\EntityBody;
 
-class MultiResultResponse extends SelfParsingResponse implements \Countable, \Iterator
+class MultiResultResponse extends SelfParsingResponse implements \Countable, \IteratorAggregate
 {
+    /**
+     * Metadata returned by API.
+     *
+     * @var array
+     */
+    private $metadata;
+
     /**
      * Makes Meetup API Data available on the Data attribute.
      */
-    public function parseMeetupApiData()
+    protected function parseMeetupApiData()
     {
         $responseBody = $this->parseBodyContent();
-        $this->setData($responseBody['results']);
-        $this->setMetadata($responseBody['meta']);
-    }
 
-    /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
-     * Count elements of an object.
-     *
-     * @link http://php.net/manual/en/countable.count.php
-     *
-     * @return int The custom count as an integer.
-     */
-    public function count()
-    {
-        return count($this->data);
+        $this->data = $responseBody['results'];
+        $this->metadata = $responseBody['meta'];
     }
 
     /**
@@ -42,7 +38,7 @@ class MultiResultResponse extends SelfParsingResponse implements \Countable, \It
     {
         $clone = clone $this;
 
-        $clone->setData(array_map($func, $this->data));
+        $clone->data = array_map($func, $this->data);
         $clone->updateBody();
 
         return $clone;
@@ -60,7 +56,7 @@ class MultiResultResponse extends SelfParsingResponse implements \Countable, \It
     {
         $clone = clone $this;
 
-        $clone->setData(array_filter($this->data, $p));
+        $clone->data = array_filter($this->data, $p);
         $clone->updateBody();
 
         return $clone;
@@ -98,68 +94,26 @@ class MultiResultResponse extends SelfParsingResponse implements \Countable, \It
     }
 
     /**
-     * (PHP 5 &gt;= 5.0.0)<br/>
-     * Return the current element.
-     *
-     * @link http://php.net/manual/en/iterator.current.php
-     *
-     * @return mixed Can return any type.
+     * @return array
      */
-    public function current()
+    public function getMetadata()
     {
-        return current($this->data);
+        return $this->metadata;
     }
 
     /**
-     * (PHP 5 &gt;= 5.0.0)<br/>
-     * Move forward to next element.
-     *
-     * @link http://php.net/manual/en/iterator.next.php
-     *
-     * @return void Any returned value is ignored.
+     * {@inheritdoc}
      */
-    public function next()
+    public function count()
     {
-        next($this->data);
+        return count($this->data);
     }
 
     /**
-     * (PHP 5 &gt;= 5.0.0)<br/>
-     * Return the key of the current element.
-     *
-     * @link http://php.net/manual/en/iterator.key.php
-     *
-     * @return mixed scalar on success, or null on failure.
+     * {@inheritdoc}
      */
-    public function key()
+    public function getIterator()
     {
-        return key($this->data);
-    }
-
-    /**
-     * (PHP 5 &gt;= 5.0.0)<br/>
-     * Checks if current position is valid.
-     *
-     * @link http://php.net/manual/en/iterator.valid.php
-     *
-     * @return bool The return value will be casted to boolean and then evaluated.
-     *              Returns true on success or false on failure.
-     */
-    public function valid()
-    {
-        return false !== current($this->data);
-    }
-
-    /**
-     * (PHP 5 &gt;= 5.0.0)<br/>
-     * Rewind the Iterator to the first element.
-     *
-     * @link http://php.net/manual/en/iterator.rewind.php
-     *
-     * @return void Any returned value is ignored.
-     */
-    public function rewind()
-    {
-        reset($this->data);
+        return new ArrayIterator($this->data);
     }
 }

--- a/src/DMS/Service/Meetup/Response/SelfParsingResponse.php
+++ b/src/DMS/Service/Meetup/Response/SelfParsingResponse.php
@@ -13,25 +13,10 @@ class SelfParsingResponse extends Response
      */
     protected $data;
 
-    /**
-     * Metadata returned by API.
-     *
-     * @var array
-     */
-    protected $metadata;
-
     public function __construct($statusCode, $headers = null, $body = null)
     {
         parent::__construct($statusCode, $headers, $body);
         $this->parseMeetupApiData();
-    }
-
-    /**
-     * @param array $data
-     */
-    public function setData($data)
-    {
-        $this->data = $data;
     }
 
     /**
@@ -43,27 +28,11 @@ class SelfParsingResponse extends Response
     }
 
     /**
-     * @param array $metadata
-     */
-    public function setMetadata($metadata)
-    {
-        $this->metadata = $metadata;
-    }
-
-    /**
-     * @return array
-     */
-    public function getMetadata()
-    {
-        return $this->metadata;
-    }
-
-    /**
      * Parses the Meetup Response based on content type.
      *
      * @return array
      */
-    public function parseBodyContent()
+    protected function parseBodyContent()
     {
         if (!$this->isContentType('json')) {
             parse_str($this->getBody(true), $array);
@@ -77,10 +46,9 @@ class SelfParsingResponse extends Response
     /**
      * Makes Meetup API Data available on the Data attribute.
      */
-    public function parseMeetupApiData()
+    protected function parseMeetupApiData()
     {
-        $responseBody = $this->parseBodyContent();
-        $this->setData($responseBody);
+        $this->data = $this->parseBodyContent();
     }
 
     /**

--- a/tests/DMS/Service/Meetup/Response/SingleResultResponseTest.php
+++ b/tests/DMS/Service/Meetup/Response/SingleResultResponseTest.php
@@ -24,12 +24,10 @@ class SingleResultResponseTest extends \PHPUnit_Framework_TestCase
         $serialized = serialize($response);
 
         $this->assertNotContains('data', $serialized);
-        $this->assertNotContains('metadata', $serialized);
 
         $unserialized = unserialize($serialized);
 
         $this->assertEquals($response->getData(), $unserialized->getData());
-        $this->assertEquals($response->getMetadata(), $unserialized->getMetadata());
 
         $this->assertInternalType('array', $unserialized->getData());
     }


### PR DESCRIPTION
- Removing setters
- Moving metadata to MultiResultResponse (only place it is used)
- Hiding things that shouldn't be accessible
- Simplifying things by using the IteratorAggregate
- Simplifying parse conditions
