### PR TITLE
Fixing issue #53: preventing a division by zero error

### DIFF
--- a/src/DMS/Service/Meetup/Plugin/RateLimitPlugin.php
+++ b/src/DMS/Service/Meetup/Plugin/RateLimitPlugin.php
@@ -145,7 +145,10 @@ class RateLimitPlugin implements EventSubscriberInterface
      */
     protected function slowdownRequests()
     {
-        $microsecondsPerRequestRemaining = $this->rateLimitReset / $this->rateLimitRemaining * 1000000;
-        usleep($microsecondsPerRequestRemaining);
+        $microsecondsPerRequestRemaining = $this->rateLimitRemaining * 1000000;
+        if (0 !== (int) $this->rateLimitRemaining) {
+            $microsecondsPerRequestRemaining = $this->rateLimitReset / $this->rateLimitRemaining * 1000000;
+        }
+        usleep((int) $microsecondsPerRequestRemaining);
     }
 }

--- a/tests/DMS/Service/Meetup/Plugin/RateLimitPluginTest.php
+++ b/tests/DMS/Service/Meetup/Plugin/RateLimitPluginTest.php
@@ -99,4 +99,21 @@ class RateLimitPluginTest extends \PHPUnit_Framework_TestCase
 
         return $plugin;
     }
+
+    /**
+     * Test to ensure a division by zero will never occur when validating
+     * the rate limit of the API call when the rate limit remaining has a
+     * value of 0
+     *
+     * @group issue-53
+     * @see https://github.com/rdohms/meetup-api-client/issues/53
+     * @covers \DMS\Service\Meetup\Plugin\RateLimitPlugin::slowdownRequests
+     */
+    public function testRateLimitDoesNotCauseDivisionByZeroError()
+    {
+        $plugin = $this->setupProxyPluginWithValues(10, 0, 10, 0.5);
+        $plugin->onBeforeSend();
+
+        $this->assertGreaterThan(0, $plugin->slowdowns);
+    }
 }


### PR DESCRIPTION
As described in issue #53, in rare occasions you hit a "division by zero" error because there's no check for the value of the divided number. This fix should solve the problem, with a unit test to ensure the issue will be covered.