### PR TITLE
Fixing issue #53: preventing a division by zero error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,14 @@ php:
   - 5.6
   - 7.0
 
+matrix:
+  include:
+    - php: 5.3
+      dist: precise
+  exclude:
+    - php: 5.3
+      dist: trusty
+
 before_script:
   - composer selfupdate
   - composer install --prefer-source --dev

--- a/src/DMS/Service/Meetup/Plugin/RateLimitPlugin.php
+++ b/src/DMS/Service/Meetup/Plugin/RateLimitPlugin.php
@@ -145,7 +145,10 @@ class RateLimitPlugin implements EventSubscriberInterface
      */
     protected function slowdownRequests()
     {
-        $microsecondsPerRequestRemaining = $this->rateLimitReset / $this->rateLimitRemaining * 1000000;
-        usleep($microsecondsPerRequestRemaining);
+        $sleepInMicroseconds = ((int) $this->rateLimitRemaining === 0)
+            ? $this->rateLimitReset * 1000000
+            : $this->rateLimitReset / $this->rateLimitRemaining * 1000000;
+
+        usleep((int) $sleepInMicroseconds);
     }
 }

--- a/tests/DMS/Service/Meetup/Plugin/RateLimitPluginTest.php
+++ b/tests/DMS/Service/Meetup/Plugin/RateLimitPluginTest.php
@@ -99,4 +99,21 @@ class RateLimitPluginTest extends \PHPUnit_Framework_TestCase
 
         return $plugin;
     }
+
+    /**
+     * Test to ensure a division by zero will never occur when validating
+     * the rate limit of the API call when the rate limit remaining has a
+     * value of 0
+     *
+     * @group issue-53
+     * @see https://github.com/rdohms/meetup-api-client/issues/53
+     * @covers \DMS\Service\Meetup\Plugin\RateLimitPlugin::slowdownRequests
+     */
+    public function testExhaustedRateLimitIsHandledWithoutDivisionByZeroError()
+    {
+        $plugin = $this->setupProxyPluginWithValues(10, 0, 1, 0.5);
+        $plugin->onBeforeSend();
+
+        $this->assertGreaterThan(0, $plugin->slowdowns);
+    }
 }


### PR DESCRIPTION
In rare occasions you hit a "division by zero" error because you no
longer have any requests remaing and there's no check for the value
of the divided number.
In this scenario the plugin should sleep until the next rate limit
reset.

This PR patches up @dragonbe's patch to force a longer sleep instead of no sleep.
Awaiting discussion in #53 to confirm desired output.